### PR TITLE
Remove dynamic exception specificatons

### DIFF
--- a/src/diagnostic.cpp
+++ b/src/diagnostic.cpp
@@ -84,7 +84,7 @@ diagnostic_base::diagnostic_base(std::string const & severity_name,
 	      << hex << setw(5) << reason << ": " << dec;
 }
 
-void diagnostic_base::despatch() const throw(unsigned)
+void diagnostic_base::despatch() const
 {
 	count();
 	if (!text().empty()) {

--- a/src/diagnostic.h
+++ b/src/diagnostic.h
@@ -295,7 +295,7 @@ protected:
 	}
 
 	/// Emit the diagnostic
-	void despatch() const throw (unsigned);
+	void despatch() const;
 
 	/// Is the diagnostic suppressed?
 	bool _gagged;


### PR DESCRIPTION
Dynamic exception specification were deprecated in C++11 and removed
in C++17. This commit removes them from the sources, to make them
compatible with the new verions of C++.